### PR TITLE
Fix compilation warning in src/cborvalidation.c

### DIFF
--- a/src/cborvalidation.c
+++ b/src/cborvalidation.c
@@ -436,7 +436,7 @@ static CborError validate_container(CborValue *it, int containerType, int flags,
 {
     CborError err;
     const uint8_t *previous = NULL;
-    const uint8_t *previous_end;
+    const uint8_t *previous_end = NULL;
 
     if (!recursionLeft)
         return CborErrorNestingTooDeep;


### PR DESCRIPTION
Fix the following warning:
src/cborvalidation.c:485:61: warning: 'previous_end' may be used uninitialized in this function [-Wmaybe-uninitialized]
  485 |                     size_t bytelen1 = (size_t)(previous_end - previous);
      |                                               ~~~~~~~~~~~~~~^~~~~~~~~~~
src/cborvalidation.c:439:20: note: 'previous_end' was declared here
  439 |     const uint8_t *previous_end;
      |                    ^~~~~~~~~~~~