### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/cborencoder.c
+++ b/src/cborencoder.c
@@ -250,14 +250,14 @@ static inline void advance_ptr(CborEncoder *encoder, size_t n)
     if (encoder->end)
         encoder->data.ptr += n;
     else
-        encoder->data.bytes_needed += n;
+        encoder->data.bytes_needed += (ptrdiff_t)n;
 }
 
 static inline CborError append_to_buffer(CborEncoder *encoder, const void *data, size_t len)
 {
     if (would_overflow(encoder, len)) {
         if (encoder->end != NULL) {
-            len -= encoder->end - encoder->data.ptr;
+            len -= (size_t)(encoder->end - encoder->data.ptr);
             encoder->end = NULL;
             encoder->data.bytes_needed = 0;
         }
@@ -289,7 +289,7 @@ static inline CborError encode_number_no_update(CborEncoder *encoder, uint64_t u
     put64(buf + 1, ui);     /* we probably have a bunch of zeros in the beginning */
 
     if (ui < Value8Bit) {
-        *bufstart += shiftedMajorType;
+        *bufstart += (uint8_t)shiftedMajorType;
     } else {
         uint8_t more = 0;
         if (ui > 0xffU)
@@ -299,10 +299,10 @@ static inline CborError encode_number_no_update(CborEncoder *encoder, uint64_t u
         if (ui > 0xffffffffU)
             ++more;
         bufstart -= (size_t)1 << more;
-        *bufstart = shiftedMajorType + Value8Bit + more;
+        *bufstart = (uint8_t)(shiftedMajorType + Value8Bit + more);
     }
 
-    return append_to_buffer(encoder, bufstart, bufend - bufstart);
+    return append_to_buffer(encoder, bufstart, (size_t)(bufend - bufstart));
 }
 
 static inline CborError encode_number(CborEncoder *encoder, uint64_t ui, uint8_t shiftedMajorType)
@@ -342,9 +342,9 @@ CborError cbor_encode_negative_int(CborEncoder *encoder, uint64_t absolute_value
 CborError cbor_encode_int(CborEncoder *encoder, int64_t value)
 {
     /* adapted from code in RFC 7049 appendix C (pseudocode) */
-    uint64_t ui = value >> 63;              /* extend sign to whole length */
+    uint64_t ui = (uint64_t)(value >> 63);              /* extend sign to whole length */
     uint8_t majorType = ui & 0x20;          /* extract major type */
-    ui ^= value;                            /* complement negatives */
+    ui ^= (uint64_t)value;                            /* complement negatives */
     return encode_number(encoder, ui, majorType);
 }
 
@@ -551,7 +551,7 @@ static CborError create_container(CborEncoder *encoder, CborEncoder *container, 
 
     if (length == CborIndefiniteLength) {
         container->flags |= CborIteratorFlag_UnknownLength;
-        err = append_byte_to_buffer(container, shiftedMajorType + IndefiniteLength);
+        err = append_byte_to_buffer(container, (uint8_t)(shiftedMajorType + IndefiniteLength));
     } else {
         err = encode_number_no_update(container, length, shiftedMajorType);
     }

--- a/src/cborencoder.c
+++ b/src/cborencoder.c
@@ -289,7 +289,7 @@ static inline CborError encode_number_no_update(CborEncoder *encoder, uint64_t u
     put64(buf + 1, ui);     /* we probably have a bunch of zeros in the beginning */
 
     if (ui < Value8Bit) {
-        *bufstart += (uint8_t)shiftedMajorType;
+        *bufstart = (uint8_t)(*bufstart + shiftedMajorType);
     } else {
         uint8_t more = 0;
         if (ui > 0xffU)

--- a/src/cborencoder.c
+++ b/src/cborencoder.c
@@ -505,7 +505,7 @@ CBOR_API CborError cbor_encode_byte_string_start(const CborEncoder *encoder, con
 CBOR_API CborError cbor_encode_byte_string_finish(CborEncoder *encoder, size_t used_length)
 {
     CborError err = CborNoError;
-    const uint8_t *start_ptr;
+    const uint8_t *start_ptr = NULL;
     size_t max_string_length;
     size_t i;
 

--- a/src/cborparser.c
+++ b/src/cborparser.c
@@ -221,7 +221,7 @@ static CborError preparse_value(CborValue *it)
         return CborErrorUnexpectedEOF;
 
     uint8_t descriptor = *it->ptr;
-    uint8_t type = descriptor & MajorTypeMask;
+    uint8_t type = descriptor & ((uint8_t)MajorTypeMask);
     it->type = type;
     it->flags = 0;
     it->extra = (descriptor &= SmallValueMask);
@@ -238,7 +238,7 @@ static CborError preparse_value(CborValue *it)
         return type == CborSimpleType ? CborErrorUnexpectedBreak : CborErrorIllegalNumber;
     }
 
-    size_t bytesNeeded = descriptor < Value8Bit ? 0 : (1 << (descriptor - Value8Bit));
+    size_t bytesNeeded = (size_t)(descriptor < Value8Bit ? 0 : (1 << (descriptor - Value8Bit)));
     if (bytesNeeded + 1 > (size_t)(parser->end - it->ptr))
         return CborErrorUnexpectedEOF;
 
@@ -1046,7 +1046,7 @@ CborError cbor_value_get_int64_checked(const CborValue *value, int64_t *result)
     if (unlikely(v > (uint64_t)INT64_MAX))
         return CborErrorDataTooLarge;
 
-    *result = v;
+    *result = (int64_t)v;
     if (value->flags & CborIteratorFlag_NegativeInteger)
         *result = -*result - 1;
     return CborNoError;

--- a/src/cborparser.c
+++ b/src/cborparser.c
@@ -318,8 +318,9 @@ static CborError preparse_next_value(CborValue *it)
 
 static CborError advance_internal(CborValue *it)
 {
-    uint64_t length;
+    uint64_t length = 0;
     CborError err = _cbor_value_extract_number(&it->ptr, it->parser->end, &length);
+    (void)err;
     cbor_assert(err == CborNoError);
 
     if (it->type == CborByteStringType || it->type == CborTextStringType) {
@@ -804,7 +805,7 @@ CborError cbor_value_enter_container(const CborValue *it, CborValue *recursed)
          * it's just an empty container */
         ++recursed->ptr;
     } else {
-        uint64_t len;
+        uint64_t len = 0;
         err = _cbor_value_extract_number(&recursed->ptr, recursed->parser->end, &len);
         cbor_assert(err == CborNoError);
 

--- a/src/cborvalidation.c
+++ b/src/cborvalidation.c
@@ -443,7 +443,7 @@ static CborError validate_container(CborValue *it, int containerType, int flags,
         return CborErrorNestingTooDeep;
 
     while (!cbor_value_at_end(it)) {
-        const uint8_t *current;
+        const uint8_t *current = NULL;
 
         if (containerType == CborMapType) {
             current = it->ptr;

--- a/src/cborvalidation.c
+++ b/src/cborvalidation.c
@@ -372,7 +372,8 @@ static inline CborError validate_tag(CborValue *it, CborTag tag, int flags, int 
 #ifndef CBOR_NO_FLOATING_POINT
 static inline CborError validate_floating_point(CborValue *it, CborType type, int flags)
 {
-    CborError err;
+    CborError err = CborNoError;
+    (void)err;
     double val;
     float valf;
     uint16_t valf16;

--- a/src/compilersupport_p.h
+++ b/src/compilersupport_p.h
@@ -228,9 +228,9 @@ static inline unsigned short encode_half(double val)
 #else
     uint64_t v;
     memcpy(&v, &val, sizeof(v));
-    int sign = v >> 63 << 15;
-    int exp = (v >> 52) & 0x7ff;
-    int mant = v << 12 >> 12 >> (53-11);    /* keep only the 11 most significant bits of the mantissa */
+    int sign = (int)(v >> 63 << 15);
+    int exp = (int)((v >> 52) & 0x7ff);
+    int mant = (int)(v << 12 >> 12 >> (53-11));    /* keep only the 11 most significant bits of the mantissa */
     exp -= 1023;
     if (exp == 1024) {
         /* infinity or NaN */


### PR DESCRIPTION
Many of these warnings were reproduced on release build type. The difference that in debug we have "assert" function defined, and due to this, we don't get unused variables warnings and others